### PR TITLE
retrieve uid from user info

### DIFF
--- a/lib/ueberauth/strategy/procore.ex
+++ b/lib/ueberauth/strategy/procore.ex
@@ -74,7 +74,7 @@ defmodule Ueberauth.Strategy.Procore do
   the user.
   """
   def uid(conn) do
-    conn.private.procore_user[:id]
+    conn.private.procore_user["id"]
   end
 
   @doc """


### PR DESCRIPTION
It seems that the `uid` field was not being set. This sets it, at least according to the data from the sandbox account I am working with.